### PR TITLE
Replace build.sh and buildjar.sh with make, also removed the need for root

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ This project is inspired by the peer-to-peer nature of Bittorrent, the decentral
 ### Installation
 The latest stable binary can be downloaded from [SquidTech](http://squid-tech.com/nodechan.html) and run.
 
-If you would like to build NodeChan from source, clone this repository and run the "build.sh" script, or otherwise compile the Java files in the "src" directory. Make sure to include "lib/*" in your classpath when compiling.
+If you would like to build NodeChan from source, clone this repository and type `make jar` to compile everything.
+
+If you're looking for a one-liner for cloning and compiling:
+`git clone https://github.com/joshiemoore/NodeChan && cd NodeChan && make jar`
 
 
 ### Running

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,0 @@
-sudo javac -cp lib/WaifUPnP.jar src/*.java -d build

--- a/buildjar.sh
+++ b/buildjar.sh
@@ -1,5 +1,0 @@
-./build.sh
-jar cfm NodeChan.jar manifest.mf build/ lib/*
-
-# compress the distributable tar file
-tar cvzf NodeChan.tar.gz NodeChan.jar build/ lib/ 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,19 @@
+NODE_DEPENDS = lib/WaifUPnP.jar src/ChanPost.java src/ChanThread.java src/GUIAddPeer.java src/GUICreateNewThread.java src/GUIMain.java src/GUIRightClickMenu.java src/GUIThreadView.java src/IncomingThread.java src/NodeChan.java src/OutgoingThread.java src/Peer.java
+JAR_DEPENDS = NodeChan.jar manifest.mf lib/WaifUPnP.jar
+
+NodeChan.jar: $(NODE_DEPENDS)
+	javac -cp lib/WaifUPnP.jar src/*.java -d build
+
+jar: $(JAR_DEPENDS)
+	make
+	jar cfm NodeChan.jar manifest.mf build/ lib/*
+
+	# compress the distributable tar file
+	tar cvzf NodeChan.tar.gz NodeChan.jar build/ lib/ 
+
+clean:
+	rm -v NodeChan.jar
+	rm -v NodeChan.tar.gz
+	# for safety, prompting the user if its okay to remove the build dir
+	rm -rIv build
+

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-sudo java -cp build/:lib/* com.squidtech.nodechan.NodeChan $1 $2 $3 $4
+java -cp build/:lib/* com.squidtech.nodechan.NodeChan $1 $2 $3 $4


### PR DESCRIPTION
Here is what and why things were done.
Every change was checked and is confirmed working.
Feel free to debate.

**Changes:**

- replaced build.sh and buildjar.sh for a makefile
- removed `sudo` from build commands since it does not require root to compile..
- removed `sudo` from run.sh since it does not seem to be needed
- updated README.md to reflect these changes

**Why replacing the build scripts was done:**

- `make` will look for dependencies before building
- makes changing the software easier
- has a clean function for easy deleting for recompiling
- more readable

new usage:

`make`         - same as build.sh
`make jar`    - same as buildjar.sh, calls make recursively
`make clean`  - deletes NodeChan.jar, its tar file, and the build folder