### PR TITLE
Fixed bugs in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,18 +2,18 @@ NODE_DEPENDS = lib/WaifUPnP.jar src/ChanPost.java src/ChanThread.java src/GUIAdd
 JAR_DEPENDS = NodeChan.jar manifest.mf lib/WaifUPnP.jar
 
 NodeChan.jar: $(NODE_DEPENDS)
+	mkdir build
 	javac -cp lib/WaifUPnP.jar src/*.java -d build
 
 jar: $(JAR_DEPENDS)
-	make
 	jar cfm NodeChan.jar manifest.mf build/ lib/*
 
 	# compress the distributable tar file
 	tar cvzf NodeChan.tar.gz NodeChan.jar build/ lib/ 
 
 clean:
-	rm -v NodeChan.jar
-	rm -v NodeChan.tar.gz
 	# for safety, prompting the user if its okay to remove the build dir
 	rm -rIv build
-
+	rm -v NodeChan.jar
+	rm -v NodeChan.tar.gz
+	


### PR DESCRIPTION
###Bug 1:
For some users, the build dir is not automatically created. It is also required for javac "The directory must already exist because `javac` does not create it." See `man javac` under the -d flag

Fixed by adding `mkdir build` to the NodeChan.jar section.

###Bug 2:
Since `make jar` requires that NodeChan.jar to be created, make builds it for us without explicitly being told to, which made it run twice.

Fixed by removing the redundant call to `make` in the jar section.

###Bug 3:
`make clean` will fail to work if the user wants to only clean up from their `make` command.

Fixed by moving the deleting of the build folder to the first step in clean so it will only fail if NodeChan wasn't fully built